### PR TITLE
Adding .gitignore to src

### DIFF
--- a/sunray/.gitignore
+++ b/sunray/.gitignore
@@ -1,0 +1,2 @@
+config.h
+/.vscode


### PR DESCRIPTION
Small change for starters: adding `.gitignore` to the repository.

Suggested: 
- to exclude config.h, which should contain personal mower configuration, thus should not be commited
- to exclude /.vscode folder for those, who are using it

This should prevent adding personal configs to pull requests by accident