### PR TITLE
make min PWM a configuration option to allow custom motor drivers

### DIFF
--- a/sunray/config_example.h
+++ b/sunray/config_example.h
@@ -134,6 +134,7 @@ Also, you may choose the serial port below for serial monitor output (CONSOLE).
 // for brushless motors, study the sections (drivers, adapter, protection etc.) in the Wiki (https://wiki.ardumower.de/index.php?title=DIY_Brushless_Driver_Board)
 // #define MOTOR_DRIVER_BRUSHLESS   1     // uncomment this for new brushless motor drivers
 #define MOTOR_DRIVER_MIN_PWM     2     // set this to 0 if you use custom motor drivers and your motors do not stop spinning when stopped
+#define MOWER_DRIVER_MIN_PWM     2     // set this to 0 if you use custom mower drivers and your motors do not stop spinning when stopped
 
 #define MOTOR_OVERLOAD_CURRENT 0.8    // gear motors overload current (amps)
 

--- a/sunray/config_example.h
+++ b/sunray/config_example.h
@@ -133,6 +133,7 @@ Also, you may choose the serial port below for serial monitor output (CONSOLE).
 // ----- gear motors --------------------------------------------------
 // for brushless motors, study the sections (drivers, adapter, protection etc.) in the Wiki (https://wiki.ardumower.de/index.php?title=DIY_Brushless_Driver_Board)
 // #define MOTOR_DRIVER_BRUSHLESS   1     // uncomment this for new brushless motor drivers
+#define MOTOR_DRIVER_MIN_PWM     2     // set this to 0 if you use custom motor drivers and your motors do not stop spinning when stopped
 
 #define MOTOR_OVERLOAD_CURRENT 0.8    // gear motors overload current (amps)
 
@@ -514,4 +515,3 @@ Also, you may choose the serial port below for serial monitor output (CONSOLE).
 // 2. Locate file 'packages/arduino/hardware/sam/xxxxx/cores/arduino/RingBuffer.h
   
 #define SERIAL_BUFFER_SIZE 1024
-

--- a/sunray/robot.cpp
+++ b/sunray/robot.cpp
@@ -57,7 +57,7 @@ MPU9250_DMP imu;
   SerialRainSensorDriver rainDriver(robotDriver);
 #else
   AmRobotDriver robotDriver;
-  AmMotorDriver motorDriver;
+  AmMotorDriver motorDriver(MOTOR_DRIVER_MIN_PWM);
   AmBatteryDriver batteryDriver;
   AmBumperDriver bumper;
   AmStopButtonDriver stopButton;

--- a/sunray/robot.cpp
+++ b/sunray/robot.cpp
@@ -57,7 +57,7 @@ MPU9250_DMP imu;
   SerialRainSensorDriver rainDriver(robotDriver);
 #else
   AmRobotDriver robotDriver;
-  AmMotorDriver motorDriver(MOTOR_DRIVER_MIN_PWM);
+  AmMotorDriver motorDriver(MOTOR_DRIVER_MIN_PWM, MOWER_DRIVER_MIN_PWM);
   AmBatteryDriver batteryDriver;
   AmBumperDriver bumper;
   AmStopButtonDriver stopButton;

--- a/sunray/src/driver/AmRobotDriver.cpp
+++ b/sunray/src/driver/AmRobotDriver.cpp
@@ -46,7 +46,7 @@ void OdometryRightISR(){
   odomTicksRight++;  
 }
 
-AmMotorDriver::AmMotorDriver(int _minPwm) : minPwm(_minPwm) {
+AmMotorDriver::AmMotorDriver(int _motorMinPwm, int _mowerMinPwm) : motorMinPwm(_motorMinPwm), mowerMinPwm(_mowerMinPwm) {
 }
     
 
@@ -130,7 +130,7 @@ void AmMotorDriver::setMC33926(int pinDir, int pinPWM, int speed) {
 // PWM                H     Reverse
 // minPwm verhindert, dass das PWM Signal 0 wird. Manche Driver brauchen einen kurzen Impuls, um das PWM zu erkennen.
 // Wenn der z.B. vom max. PWM Wert auf 0 bzw. das Signal auf Low geht, behalten diese den vorherigen Wert bei und der Motor stoppt nicht.
-void AmMotorDriver::setBrushless(int pinDir, int pinPWM, int speed) {
+void AmMotorDriver::setBrushless(int pinDir, int pinPWM, int speed, int minPwm) {
   //DEBUGLN(speed);
   digitalWrite(pinDir, speed < 0 ? HIGH : LOW);
   pinMan.analogWrite(pinPWM, (byte) max(minPwm, abs(speed)) );
@@ -139,9 +139,9 @@ void AmMotorDriver::setBrushless(int pinDir, int pinPWM, int speed) {
     
 void AmMotorDriver::setMotorPwm(int leftPwm, int rightPwm, int mowPwm){
   #ifdef MOTOR_DRIVER_BRUSHLESS
-    setBrushless(pinMotorLeftDir, pinMotorLeftPWM, leftPwm);
-    setBrushless(pinMotorRightDir, pinMotorRightPWM, rightPwm);
-    setBrushless(pinMotorMowDir, pinMotorMowPWM, mowPwm);
+    setBrushless(pinMotorLeftDir, pinMotorLeftPWM, leftPwm, motorMinPwm);
+    setBrushless(pinMotorRightDir, pinMotorRightPWM, rightPwm, motorMinPwm);
+    setBrushless(pinMotorMowDir, pinMotorMowPWM, mowPwm, mowerMinPwm);
   #else
     setMC33926(pinMotorLeftDir, pinMotorLeftPWM, leftPwm);
     setMC33926(pinMotorRightDir, pinMotorRightPWM, rightPwm);

--- a/sunray/src/driver/AmRobotDriver.cpp
+++ b/sunray/src/driver/AmRobotDriver.cpp
@@ -128,19 +128,12 @@ void AmMotorDriver::setMC33926(int pinDir, int pinPWM, int speed) {
 // IN1 PinPWM         IN2 PinDir
 // PWM                L     Forward
 // PWM                H     Reverse
-// verhindert dass das PWM Signal 0 wird. Der Driver braucht einen kurzen Impuls um das PWM zu erkennen.
-// Wenn der z.B. vom max. PWM Wert auf 0 bzw. das Signal auf Low geht, behält er den vorherigen Wert bei und der Motor stoppt nicht
+// minPwm verhindert, dass das PWM Signal 0 wird. Manche Driver brauchen einen kurzen Impuls, um das PWM zu erkennen.
+// Wenn der z.B. vom max. PWM Wert auf 0 bzw. das Signal auf Low geht, behalten diese den vorherigen Wert bei und der Motor stoppt nicht.
 void AmMotorDriver::setBrushless(int pinDir, int pinPWM, int speed) {
   //DEBUGLN(speed);
-  if (speed < 0) {
-    digitalWrite(pinDir, HIGH) ;
-    if (abs(speed) < minPwm) speed = -minPwm;
-    pinMan.analogWrite(pinPWM, ((byte)abs(speed)));      
-  } else {
-    digitalWrite(pinDir, LOW) ;
-    if (abs(speed) < minPwm) speed = minPwm;
-    pinMan.analogWrite(pinPWM, ((byte)abs(speed)));      
-  }
+  digitalWrite(pinDir, speed < 0 ? HIGH : LOW);
+  pinMan.analogWrite(pinPWM, (byte) max(minPwm, abs(speed)) );
 }
 
     

--- a/sunray/src/driver/AmRobotDriver.cpp
+++ b/sunray/src/driver/AmRobotDriver.cpp
@@ -46,7 +46,7 @@ void OdometryRightISR(){
   odomTicksRight++;  
 }
 
-AmMotorDriver::AmMotorDriver(){
+AmMotorDriver::AmMotorDriver(int _minPwm) : minPwm(_minPwm) {
 }
     
 
@@ -134,11 +134,11 @@ void AmMotorDriver::setBrushless(int pinDir, int pinPWM, int speed) {
   //DEBUGLN(speed);
   if (speed < 0) {
     digitalWrite(pinDir, HIGH) ;
-    if (speed >= -2) speed = -2;                         
+    if (abs(speed) < minPwm) speed = -minPwm;
     pinMan.analogWrite(pinPWM, ((byte)abs(speed)));      
   } else {
     digitalWrite(pinDir, LOW) ;
-    if (speed <= 2) speed = 2;                           
+    if (abs(speed) < minPwm) speed = minPwm;
     pinMan.analogWrite(pinPWM, ((byte)abs(speed)));      
   }
 }

--- a/sunray/src/driver/AmRobotDriver.h
+++ b/sunray/src/driver/AmRobotDriver.h
@@ -22,9 +22,10 @@ class AmRobotDriver {
 
 class AmMotorDriver: public MotorDriver {
   private:
-    int minPwm;
+    int motorMinPwm;
+    int mowerMinPwm;
   public:    
-    AmMotorDriver(int _minPwm);
+    AmMotorDriver(int _motorMinPwm, int _mowerMinPwm);
     void begin() override;
     void run() override;
     void setMotorPwm(int leftPwm, int rightPwm, int mowPwm) override;
@@ -34,7 +35,7 @@ class AmMotorDriver: public MotorDriver {
     void getMotorEncoderTicks(int &leftTicks, int &rightTicks, int &mowTicks) override;
   protected:
     void setMC33926(int pinDir, int pinPWM, int speed);
-    void setBrushless(int pinDir, int pinPWM, int speed);
+    void setBrushless(int pinDir, int pinPWM, int speed, int minPwm);
 };
 
 class AmBatteryDriver : public BatteryDriver {

--- a/sunray/src/driver/AmRobotDriver.h
+++ b/sunray/src/driver/AmRobotDriver.h
@@ -21,8 +21,10 @@ class AmRobotDriver {
 
 
 class AmMotorDriver: public MotorDriver {
+  private:
+    int minPwm;
   public:    
-    AmMotorDriver();
+    AmMotorDriver(int _minPwm);
     void begin() override;
     void run() override;
     void setMotorPwm(int leftPwm, int rightPwm, int mowPwm) override;


### PR DESCRIPTION
The AmMotorDriver class currently never sends a PWM value below 2 to brushless motor drivers to make sure the motor driver never receives a LOW level on the PWM signal input. This impacts the use of custom motor driver hardware requiring a value of 0 to stop the motor.

This pull requests adds the option `MOTOR_DRIVER_MIN_PWM` to `config.h` so a user can change this value to 0 when sensitive motor drivers are used.