### PR TITLE
basic mqtt support with ESP32

### DIFF
--- a/esp32_ble/ardumower_adapter.h
+++ b/esp32_ble/ardumower_adapter.h
@@ -1,0 +1,385 @@
+#ifndef _ARDUMOWER_ADAPTER_H
+#define _ARDUMOWER_ADAPTER_H
+
+#include <list>
+#include <ArduinoJson.h>
+#include "./src/encrypt.h"
+#include "./src/checksum.h"
+
+namespace ArduMower {
+
+// does not change during runtime
+class Properties {
+  public:
+    String firmware;
+    String version;
+};
+
+// changes during runtime
+namespace State {
+class Point {
+  public:
+    float x, y;
+
+    Point()
+      : x(0), y(0)
+    {};
+
+    JsonObject toJsonObject();
+};
+
+class Position : public Point {
+  public:
+    float delta;
+    int solution;
+    float age;
+    float accuracy;
+    int visibleSatellites, visibleSatellitesDgps;
+    int mowPointIndex;
+
+    Position()
+      : delta(0),
+        solution(0), age(0), accuracy(0), visibleSatellites(0), visibleSatellitesDgps(0),
+        mowPointIndex(0)
+    {};
+
+    JsonObject toJsonObject();
+};
+
+class State {
+  public:
+    float batteryVoltage;
+    Position position;
+    Point target;
+    int job;
+    int sensor;
+    float amps;
+    int mapCrc;
+
+    State()
+      : batteryVoltage(0), job(0), sensor(0), amps(0), mapCrc(0)
+    {}
+
+    String toJson();
+};
+
+};
+
+class Adapter {
+  private:
+    Stream& io;
+    Encrypt enc;
+
+    // uart traffic buffers
+    String txBuffer, rxBuffer;
+    bool txBufferDirty, rxBufferDirty;
+
+    // data freshness
+    uint32_t timeAtv, timeAts;
+
+    // mutators
+    void processTxBuffer(uint32_t now);
+    void processRxBuffer(uint32_t now);
+    void decryptBuffer(String& buffer);
+
+    void processATVResponse(uint32_t now, String& res);
+    void processATSResponse(uint32_t now, String& res);
+
+    void processCSVResponse(String& res, std::function<void(int, String&)> fn);
+
+  public:
+    // business end
+    Properties props;
+    State::State state;
+    std::list<std::function<void(State::State&)>> stateListeners;
+    std::list<std::function<void(Properties&)>> propertiesListeners;
+
+    Adapter(Stream& _io, int encryptPass, bool encryptionOn)
+      : io(_io),
+      txBuffer(""), rxBuffer(""), txBufferDirty(false), rxBufferDirty(false),
+      timeAtv(0), timeAts(0)
+    {
+      enc.setPassword(encryptPass);
+    };
+
+    void loop(uint32_t now);
+
+    // ESP sends data to ArduMower
+    void tx(String& s);
+    void tx(char c);
+
+    // ESP receives data from ArduMower
+    void rx(char c);
+
+    void addStateListener(std::function<void(State::State& s)> fn) {
+      stateListeners.push_back(fn);
+    }
+
+    void addPropertiesListeners(std::function<void(Properties& p)> fn) {
+      propertiesListeners.push_back(fn);
+    }
+
+    uint32_t ageAtv(uint32_t now) { return now - timeAtv; }
+    uint32_t ageAts(uint32_t now) { return now - timeAts; }
+
+    void sendCommand(String cmd);
+};
+
+};
+
+void ArduMower::Adapter::loop(uint32_t now) {
+  if (txBufferDirty) processTxBuffer(now);
+
+  if (rxBufferDirty) processRxBuffer(now);
+}
+
+void ArduMower::Adapter::tx(String& s) {
+  txBuffer += s;
+  txBufferDirty = true;
+}
+
+void ArduMower::Adapter::tx(char c) {
+  if (c == 0) return;
+  
+  txBuffer += c;
+  txBufferDirty = true;
+}
+
+void ArduMower::Adapter::rx(char c) {
+  if (c == 0) return;
+  
+  rxBuffer += c;
+  rxBufferDirty = true;
+}
+
+void ArduMower::Adapter::processTxBuffer(uint32_t now) {
+  txBufferDirty = false;
+
+  const int index = txBuffer.indexOf("\r\n");
+  if (index == -1) return;
+
+  String buffer = txBuffer.substring(0, index);
+  String rest = txBuffer.substring(index + 2);
+
+  String s = buffer.substring(0, 4);
+
+  // the phone app sends the "AT+V" command
+  if (s == "AT+V") return;
+
+  decryptBuffer(buffer);
+
+  // TODO read waypoints, stuff
+
+  txBuffer = rest;
+  if (rest.length() > 0) txBufferDirty = true;
+}
+
+void ArduMower::Adapter::processRxBuffer(uint32_t now) {
+  rxBufferDirty = false;
+
+  const int index = rxBuffer.indexOf("\r\n");
+  if (index == -1) return;
+
+  String buffer = rxBuffer.substring(0, index);
+  String rest = rxBuffer.substring(index + 2);
+
+  rxBuffer = rest;
+  if (rest.length() > 0) {
+    rxBufferDirty = true;
+  }
+
+  if (buffer.length() < 1) return;
+
+  unsigned char crc = 0;
+  bool checkCrc = false;
+
+  if (buffer.length() >= 5) {
+    String crcVal = buffer.substring(buffer.length() - 5);
+    if (crcVal.startsWith(",0x")) {
+      crc += ((0xf * crcVal[3 + 0]) + crcVal[3 + 1]);
+      checkCrc = true;
+    }
+  }
+
+  const auto index2 = buffer.indexOf(",");
+  String responseType = buffer;
+  String remainder = "";
+
+  if (index2 != -1) {
+    responseType = buffer.substring(0, index2);
+    remainder = buffer.substring(index2 + 1);
+  }
+
+  if (responseType == "V") processATVResponse(now, remainder);
+  else if (responseType == "S") processATSResponse(now, remainder);
+  else CONSOLE.printf("adapter::unknown-response-type (%s)\n", responseType);
+}
+
+void ArduMower::Adapter::decryptBuffer(String& buffer) {
+  char* buf = strdup(buffer.c_str());
+  enc.encrypt(buf, strlen(buf));
+  free(buf);
+  buffer = String(buf);
+}
+
+void ArduMower::Adapter::processATVResponse(uint32_t now, String& res) {
+  processCSVResponse(res, [ = ](int index, String & val) {
+    // [V,]Ardumower Sunray,1.0.189,1,73,0x58\r
+    switch (index) {
+      case 0:
+        props.firmware = val;
+        break;
+      case 1:
+        props.version = val;
+        break;
+      case 2:
+        enc.setOn(val.toInt() == 1);
+        break;
+      case 3:
+        enc.setChallenge(val.toInt());
+        break;
+    }
+  });
+
+  timeAtv = now;
+  
+  for (auto it : propertiesListeners) {
+    it(props);
+  }
+}
+
+void ArduMower::Adapter::processATSResponse(uint32_t now, String& res) {
+  processCSVResponse(res, [ = ](int index, String & val) {
+    switch (index) {
+      case 0:
+        state.batteryVoltage = val.toFloat();
+        break;
+      case 1:
+        state.position.x = val.toFloat();
+        break;
+      case 2:
+        state.position.y = val.toFloat();
+        break;
+      case 3:
+        state.position.delta = val.toFloat();
+        break;
+      case 4:
+        state.position.solution = val.toInt();
+        break;
+      case 5:
+        state.job = val.toInt();
+        break;
+      case 6:
+        state.position.mowPointIndex = val.toInt();
+        break;
+      case 7:
+        state.position.age = val.toFloat();
+        break;
+      case 8:
+        state.sensor = val.toInt();
+        break;
+
+      case 9:
+        state.target.x = val.toFloat();
+        break;
+      case 10:
+        state.target.y = val.toFloat();
+        break;
+
+      case 11:
+        state.position.accuracy = val.toFloat();
+        break;
+      case 12:
+        state.position.visibleSatellites = val.toInt();
+        break;
+      case 13:
+        state.amps = val.toFloat();
+        break;
+      case 14:
+        state.position.visibleSatellitesDgps = val.toInt();
+        break;
+      case 15:
+        state.mapCrc = val.toInt();
+        break;
+    }
+  });
+
+  timeAts = now;
+  
+  for (auto it : stateListeners) {
+    it(state);
+  }
+}
+
+void ArduMower::Adapter::processCSVResponse(String& res, std::function<void(int, String&)> fn) {
+  int index = -1;
+
+  while (res.length() > 0) {
+    index++;
+
+    const auto delimiter = res.indexOf(",");
+    String val = delimiter == -1 ? res : res.substring(0, delimiter);
+
+    fn(index, val);
+
+    if (delimiter != -1) res = res.substring(delimiter + 1);
+    else res = "";
+  }
+}
+
+void ArduMower::Adapter::sendCommand(String cmd) {
+  Checksum chk;
+  chk.update(cmd);
+
+  char* buf;
+  asprintf(&buf, "%s,0x%02x", cmd.c_str(), chk);
+  enc.encrypt(buf, strlen(buf));
+
+  String result = String(buf);
+  result += "\r\n";
+  io.print(result.c_str());
+  
+  free(buf);
+}
+
+String ArduMower::State::State::toJson() {
+  String result = "";
+  DynamicJsonDocument doc(1024);
+
+  doc["battery_voltage"] = batteryVoltage;
+  doc["position"] = position.toJsonObject();
+  doc["target"] = target.toJsonObject();
+  doc["job"] = job;
+  doc["sensor"] = sensor;
+  doc["amps"] = amps;
+  doc["map_crc"] = mapCrc;
+
+  serializeJson(doc, result);
+  
+  return result;
+}
+
+JsonObject ArduMower::State::Point::toJsonObject() {
+  DynamicJsonDocument doc(1024);
+  doc["x"] = x;
+  doc["y"] = y;
+
+  return doc.as<JsonObject>();
+}
+
+JsonObject ArduMower::State::Position::toJsonObject() {
+  DynamicJsonDocument doc(1024);
+  doc["x"] = x;
+  doc["y"] = y;
+  doc["delta"] = delta;
+  doc["solution"] = solution;
+  doc["age"] = age;
+  doc["accuracy"] = accuracy;
+  doc["visible_satellites"] = visibleSatellites;
+  doc["visible_satellites_dgps"] = visibleSatellitesDgps;
+  doc["mow_point_index"] = mowPointIndex;
+
+  return doc.as<JsonObject>();
+}
+
+#endif

--- a/esp32_ble/mqtt.ino
+++ b/esp32_ble/mqtt.ino
@@ -1,0 +1,129 @@
+#include <WiFi.h>
+/*
+   MQTT
+   Joel Gaehwiler
+   2.5.0
+   https://github.com/256dpi/arduino-mqtt
+*/
+#include <MQTT.h>
+/*
+    ArduinoJson
+   Benoit Blanchon
+   6.18.4
+   https://arduinojson.org/
+*/
+#include <ArduinoJson.h>
+
+#define MQTT_MOWER_POLL_INTERVAL      1000
+#define MQTT_MOWER_POLL_BACKOFF       5000
+#define MQTT_MOWER_POLL_ATS           5000
+
+WiFiClient mqttNet;
+MQTTClient mqttClient(1024);
+bool mqttPendingPublishState = false;
+
+void mqtt_on_message(String &topic, String &payload);
+void mqtt_handle_command_start(DynamicJsonDocument& doc);
+void mqtt_handle_command_stop(DynamicJsonDocument& doc);
+void mqtt_handle_command_dock(DynamicJsonDocument& doc);
+
+void mqtt_setup() {
+#if MQTT_ENABLED
+  mower.addStateListener([ = ](ArduMower::State::State & state) {
+    mqttPendingPublishState = true;
+  });
+  mower.addPropertiesListeners([ = ](ArduMower::Properties & props) {
+//    mqttPendingPublishProps = true;
+  });
+
+  mqttClient.begin(MQTT_HOSTNAME, mqttNet);
+  mqttClient.onMessage(mqtt_on_message);
+#endif
+}
+
+void mqtt_loop() {
+#if MQTT_ENABLED
+  mqtt_poll_mower(millis());
+  mqtt_connect();
+  mqttClient.loop();
+  mqtt_publish_state();
+#endif
+}
+
+void mqtt_poll_mower(uint32_t now) {
+  static uint32_t next_time = 0;
+  if (now < next_time) return;
+  next_time = now + MQTT_MOWER_POLL_INTERVAL;
+
+  if (mower.ageAtv(0) == 0) {
+    static uint32_t last_time = 0;
+    if (now - last_time > MQTT_MOWER_POLL_BACKOFF) {
+      last_time = now;
+      mower.sendCommand("AT+V");
+      return;
+    }
+  }
+  
+  if (mower.ageAts(now) >= MQTT_MOWER_POLL_ATS) {
+    static uint32_t last_time = 0;
+    if (now - last_time > MQTT_MOWER_POLL_BACKOFF) {
+      last_time = now;
+      mower.sendCommand("AT+S");
+      return;
+    }
+  }
+}
+
+void mqtt_connect() {
+  if (mqttClient.connected()) return;
+  
+  if (!mqttClient.connect(MQTT_CLIENT_ID, MQTT_USERNAME, MQTT_PASSWORD)) return;
+
+  mqttClient.subscribe(mqtt_topic("/command").c_str());
+  mqttClient.publish(mqtt_topic("/online").c_str(), "true");
+  mqttClient.setWill(mqtt_topic("/online").c_str(), "false");
+}
+
+void mqtt_on_message(String &topic, String &payload) {
+  DynamicJsonDocument doc(1024);
+  deserializeJson(doc, payload);
+
+  String command = doc["command"];
+
+  if (command == "start") {
+    mqtt_handle_command_start(doc);
+  } else if (command == "stop") {
+    mqtt_handle_command_stop(doc);
+  } else if (command == "dock") {
+    mqtt_handle_command_dock(doc);
+  }
+}
+
+void mqtt_publish_state() {
+  if (!mqttPendingPublishState) return;
+
+  if (!mqttClient.publish(mqtt_topic("/state").c_str(), mower.state.toJson().c_str())) return;
+
+  mqttPendingPublishState = false;
+}
+
+void mqtt_handle_command_start(DynamicJsonDocument& doc) {
+  String at = "AT+C,-1,1,0.1,100,0,-1,-1,1";
+  mower.sendCommand(at);
+}
+
+void mqtt_handle_command_stop(DynamicJsonDocument& doc) {
+  mower.sendCommand("AT+C,-1,0,-1,-1,-1,-1,-1,-1");
+}
+
+void mqtt_handle_command_dock(DynamicJsonDocument& doc) {
+  mower.sendCommand("AT+C,-1,4,-1,-1,-1,-1,-1,1");
+}
+
+String mqtt_topic(String postfix) {
+  String result = MQTT_PREFIX;
+  result += MQTT_CLIENT_ID;
+  result += postfix;
+
+  return result;
+}

--- a/esp32_ble/src/checksum.h
+++ b/esp32_ble/src/checksum.h
@@ -1,0 +1,27 @@
+#ifndef _CHECKSUM_H
+#define _CHECKSUM_H
+
+#include <string.h>
+
+namespace ArduMower
+{
+  class Checksum
+  {
+  private:
+    unsigned char val;
+  public:
+    Checksum() : val(0) {}
+
+    void update(char c) { val += c; };
+
+    void update(String& s) {
+      for(int i=0; i < s.length(); i++) {
+        update(s[i]);
+      }
+    }
+
+    unsigned char value() { return val; }
+  };  
+}
+
+#endif

--- a/esp32_ble/src/encrypt.h
+++ b/esp32_ble/src/encrypt.h
@@ -1,0 +1,79 @@
+#ifndef _ENCODE_H
+#define _ENCODE_H
+
+#include <stddef.h>
+#include <inttypes.h>
+#include <stdio.h>
+
+namespace ArduMower
+{
+  class Encrypt
+  {
+  private:
+    bool on;
+    int password;
+    int challenge;
+    int key;
+
+    void calculateKey();
+  public:
+    Encrypt() : on(false), password(0), challenge(0), key(0) {}
+
+    void encrypt(char* buffer, size_t len);
+    void decrypt(char* buffer, size_t len);
+
+    void setOn(bool enabled) {
+      on = enabled;
+    }
+
+    void setPassword(int p) { 
+      password = p;
+      calculateKey();
+    }
+
+    void setChallenge(int c) {
+      challenge = c;
+      calculateKey();
+    }
+  };
+  
+}
+
+void ArduMower::Encrypt::calculateKey() {
+  if (password == 0) return;
+  if (challenge == 0) return;
+
+  key = password % challenge;
+}
+
+void ArduMower::Encrypt::encrypt(char* buffer, size_t len) {
+  if (!on || key == 0) return;
+
+  for (int i=0; i < len; i++) {
+    const unsigned char b = (unsigned char)buffer[i];
+    int c = b;
+
+    c += key;
+    if (c > 126) c -= (126 - 31);
+
+    buffer[i] = (char)c;
+  }
+}
+
+void ArduMower::Encrypt::decrypt(char* buffer, size_t len) {
+  if (!on || key == 0) return;
+
+  for (int i = 0; i < len; i++) {
+    const unsigned char b = (unsigned char)buffer[i];
+    if (b < 32 || b > 126) continue;
+
+    int c = b;
+
+    c -= key;
+    if (c <= 31) c += (126 - 31);
+
+    buffer[i] = (char)c;
+  }
+}
+
+#endif


### PR DESCRIPTION
This PR adds MQTT support to the ESP32. The ESP sends status updates to an MQTT topic and can receive basic commands on a command topic. All MQTT payloads are JSON formatted.

It works by parsing the between ESP and ArduMower. As long as an app is connected by WiFi or Bluetooth, the status responses by ArduMower are parsed and published to an MQTT topic. If no app is connected and there are no status updates, then the ESP periodically sends `AT+S` commands publish fresh status values on MQTT.