### PR TITLE
Map Stanley Control parameters linearspeedset from motor.setlinearangularspeed

### DIFF
--- a/sunray/robot.cpp
+++ b/sunray/robot.cpp
@@ -1430,12 +1430,15 @@ void trackLine(){
       if (sonar.nearObstacle()) linear = 0.1; // slow down near obstacles
     }      
     //angula                                    r = 3.0 * trackerDiffDelta + 3.0 * lateralError;       // correct for path errors 
-    float k = stanleyTrackingNormalK; // STANLEY_CONTROL_K_NORMAL;
-    float p = stanleyTrackingNormalP; // STANLEY_CONTROL_P_NORMAL;    
-    if (maps.trackSlow) {
-      k = stanleyTrackingSlowK; //STANLEY_CONTROL_K_SLOW;   
-      p = stanleyTrackingSlowP; //STANLEY_CONTROL_P_SLOW;          
-    }
+    
+    //Mapping of Stanley Control Parameters in relation to actual Setpoint value of speed
+    //Values need to be multiplied, because map() function does not work well with small range decimals
+    float CurrSpeed = motor.linearSpeedSet * 1000;                                                    
+    float k = map(CurrSpeed, 100, 400, STANLEY_CONTROL_K_SLOW*1000, STANLEY_CONTROL_K_NORMAL*1000);  //Value 100 and 400 is in mm/s 
+    float p = map(CurrSpeed, 100, 400, STANLEY_CONTROL_P_SLOW*1000, STANLEY_CONTROL_P_NORMAL*1000);  //Value 100 and 400 is in mm/s 
+    k = k / 1000;                                                                                     
+    p = p / 1000;                                                                                     
+    
     angular =  p * trackerDiffDelta + atan2(k * lateralError, (0.001 + fabs(motor.linearSpeedSet)));       // correct for path errors           
     /*pidLine.w = 0;              
     pidLine.x = lateralError;

--- a/sunray/robot.cpp
+++ b/sunray/robot.cpp
@@ -1433,7 +1433,8 @@ void trackLine(){
     
     //Mapping of Stanley Control Parameters in relation to actual Setpoint value of speed
     //Values need to be multiplied, because map() function does not work well with small range decimals
-    float CurrSpeed = motor.linearSpeedSet * 1000;                                                    
+    float CurrSpeed = motor.linearSpeedSet * 1000; 
+    CurrSpeed = abs(CurrSpeed);
     float k = map(CurrSpeed, 100, 400, STANLEY_CONTROL_K_SLOW*1000, STANLEY_CONTROL_K_NORMAL*1000);  //Value 100 and 400 is in mm/s 
     float p = map(CurrSpeed, 100, 400, STANLEY_CONTROL_P_SLOW*1000, STANLEY_CONTROL_P_NORMAL*1000);  //Value 100 and 400 is in mm/s 
     k = k / 1000;                                                                                     

--- a/sunray/robot.cpp
+++ b/sunray/robot.cpp
@@ -1435,8 +1435,8 @@ void trackLine(){
     //Values need to be multiplied, because map() function does not work well with small range decimals
     float CurrSpeed = motor.linearSpeedSet * 1000; 
     CurrSpeed = abs(CurrSpeed);
-    float k = map(CurrSpeed, 100, 600, STANLEY_CONTROL_K_SLOW*1000, STANLEY_CONTROL_K_NORMAL*1000);  //Value 100 and 400 is in mm/s 
-    float p = map(CurrSpeed, 100, 600, STANLEY_CONTROL_P_SLOW*1000, STANLEY_CONTROL_P_NORMAL*1000);  //Value 100 and 400 is in mm/s 
+    float k = map(CurrSpeed, MINSPEED*1000, MAXSPEED*1000, STANLEY_CONTROL_K_SLOW*1000, STANLEY_CONTROL_K_NORMAL*1000);  //MINSPEED and MAXSPEED from config.h
+    float p = map(CurrSpeed, MINSPEED*1000, MAXSPEED*1000, STANLEY_CONTROL_P_SLOW*1000, STANLEY_CONTROL_P_NORMAL*1000);  //MINSPEED and MAXSPEED from config.h
     k = k / 1000;                                                                                     
     p = p / 1000;                                                                                     
     

--- a/sunray/robot.cpp
+++ b/sunray/robot.cpp
@@ -1435,8 +1435,8 @@ void trackLine(){
     //Values need to be multiplied, because map() function does not work well with small range decimals
     float CurrSpeed = motor.linearSpeedSet * 1000; 
     CurrSpeed = abs(CurrSpeed);
-    float k = map(CurrSpeed, 100, 400, STANLEY_CONTROL_K_SLOW*1000, STANLEY_CONTROL_K_NORMAL*1000);  //Value 100 and 400 is in mm/s 
-    float p = map(CurrSpeed, 100, 400, STANLEY_CONTROL_P_SLOW*1000, STANLEY_CONTROL_P_NORMAL*1000);  //Value 100 and 400 is in mm/s 
+    float k = map(CurrSpeed, 100, 600, STANLEY_CONTROL_K_SLOW*1000, STANLEY_CONTROL_K_NORMAL*1000);  //Value 100 and 400 is in mm/s 
+    float p = map(CurrSpeed, 100, 600, STANLEY_CONTROL_P_SLOW*1000, STANLEY_CONTROL_P_NORMAL*1000);  //Value 100 and 400 is in mm/s 
     k = k / 1000;                                                                                     
     p = p / 1000;                                                                                     
     


### PR DESCRIPTION
This just maps the Stanley Control Parameters linear between 2 Speeds, High and Low.
I think this is especially usefull with adaptive mowing speeds or different travel speeds which
i hope will come to sunray-master in the future. e.g trackFast/trackSlow/trackMow (trackMow would be adaptive to actual mowload)
i already added trackFast in maps. and currently testing it.
For operations like WAY_FREE when traveling to dock or mowarea or Status Raintriggered true.