### PR TITLE
SerialRobotDriverp: use higher cpu fan temps for Alfred (65 and 60)

### DIFF
--- a/sunray/src/driver/SerialRobotDriver.cpp
+++ b/sunray/src/driver/SerialRobotDriver.cpp
@@ -517,9 +517,9 @@ void SerialRobotDriver::run(){
   if (millis() > nextTempTime){
     nextTempTime = millis() + 59000; // 59 sec
     updateCpuTemperature();
-    if (cpuTemp < 50){      
+    if (cpuTemp < 60){      
       setFanPowerState(false);
-    } else if (cpuTemp > 55){
+    } else if (cpuTemp > 65){
       setFanPowerState(true);
     }
   }


### PR DESCRIPTION
this one raises the default cpu temps for alfred. 50 and 55 results in 24/7 fan run for summer nights. 65 and 60 ensures idle fans most of the time