### PR TITLE
Sunray: fix turn preference for mowers with FREEWHEEL_IS_AT_BACKSIDE

### DIFF
--- a/alfred/config.h
+++ b/alfred/config.h
@@ -114,6 +114,7 @@ Also, you may choose the serial port below for serial monitor output (CONSOLE).
 #define FREEWHEEL_IS_AT_BACKSIDE   false   // default Ardumower: true   (change to false, if your freewheel is at frontside) - this is used for obstacle avoidance
 #define WHEEL_BASE_CM         39         // wheel-to-wheel distance (cm)        
 #define WHEEL_DIAMETER        205        // wheel diameter (mm)                 
+#define MOWER_SIZE            60         // mower / chassis size / length in cm
 
 //#define ENABLE_ODOMETRY_ERROR_DETECTION  true    // use this to detect odometry erros
 #define ENABLE_ODOMETRY_ERROR_DETECTION  false

--- a/sunray/LineTracker.cpp
+++ b/sunray/LineTracker.cpp
@@ -38,7 +38,7 @@ int get_turn_direction_preference() {
   float targetDelta = pointsAngle(stateX, stateY, target.x(), target.y());
   float center_x = stateX;
   float center_y = stateY;
-  float r = 0.3;
+  float r = (MOWER_SIZE / 100);
   float cur_angle = stateDelta;
 
   if (FREEWHEEL_IS_AT_BACKSIDE) {

--- a/sunray/LineTracker.cpp
+++ b/sunray/LineTracker.cpp
@@ -39,6 +39,12 @@ int get_turn_direction_preference() {
   float center_x = stateX;
   float center_y = stateY;
   float r = 0.3;
+  float cur_angle = stateDelta;
+
+  if (FREEWHEEL_IS_AT_BACKSIDE) {
+	  cur_angle = scalePI(stateDelta + PI);
+	  targetDelta = scalePI(targetDelta + PI);
+  }
 
   // create circle / octagon around center angle 0 - "360"
   circle.points[0].setXY(center_x + cos(deg2rad(0)) * r, center_y + sin(deg2rad(0)) * r);
@@ -56,7 +62,7 @@ int get_turn_direction_preference() {
   // CONSOLE.print("/");
   // CONSOLE.print(stateY);
   // CONSOLE.print(" stateDelta: ");
-  // CONSOLE.print(stateDelta);
+  // CONSOLE.print(cur_angle);
   // CONSOLE.print(" targetDelta: ");
   // CONSOLE.println(targetDelta);
   int right = 0;
@@ -73,18 +79,18 @@ int get_turn_direction_preference() {
     if (maps.checkpoint(circle.points[i].x(), circle.points[i].y())) {
 
             // skip points in front of us
-            if (fabs(angle-stateDelta) < 0.05) {
+            if (fabs(angle-cur_angle) < 0.05) {
                     continue;
             }
 
-            if (stateDelta < targetDelta) {
-                if (angle >= stateDelta && angle <= targetDelta) {
+            if (cur_angle < targetDelta) {
+                if (angle >= cur_angle && angle <= targetDelta) {
                     left++;
                 } else {
                     right++;
                 }
             } else {
-                   if (angle <= stateDelta && angle >= targetDelta) {
+                   if (angle <= cur_angle && angle >= targetDelta) {
                     right++;
                 } else {
                     left++;

--- a/sunray/config_example.h
+++ b/sunray/config_example.h
@@ -117,6 +117,7 @@ Also, you may choose the serial port below for serial monitor output (CONSOLE).
 #define FREEWHEEL_IS_AT_BACKSIDE   true   // default Ardumower: true   (change to false, if your freewheel is at frontside) - this is used for obstacle avoidance
 #define WHEEL_BASE_CM         36         // wheel-to-wheel distance (cm)        
 #define WHEEL_DIAMETER        250        // wheel diameter (mm)                 
+#define MOWER_SIZE            60         // mower / chassis size / length in cm
 
 //#define ENABLE_ODOMETRY_ERROR_DETECTION  true    // use this to detect odometry erros
 #define ENABLE_ODOMETRY_ERROR_DETECTION  false


### PR DESCRIPTION
This pull request fixes: https://forum.ardumower.de/threads/merkw%C3%BCrdiges-wendeverhalten-am-bahnende.25106/

It also makes the mower size / length configurable. The default for alfred and ardumower is 60cm