### PR TITLE
implement Save Mow Motor Direction

### DIFF
--- a/sunray/Storage.cpp
+++ b/sunray/Storage.cpp
@@ -20,7 +20,7 @@ double stateCRC = 0;
 double calcStateCRC(){
  return (stateOp *10 + maps.mowPointsIdx + maps.dockPointsIdx + maps.freePointsIdx + ((byte)maps.wayMode) 
    + sonar.enabled + fixTimeout 
-   + ((byte)absolutePosSource) + absolutePosSourceLon + absolutePosSourceLat);
+   + ((byte)absolutePosSource) + absolutePosSourceLon + absolutePosSourceLat + motor.pwmMaxMow + finishAndRestart + motor.motorMowForwardSet);
 }
 
 
@@ -55,7 +55,13 @@ void dumpState(){
   CONSOLE.print(" lon=");
   CONSOLE.print(absolutePosSourceLon);
   CONSOLE.print(" lat=");
-  CONSOLE.println(absolutePosSourceLat);
+  CONSOLE.print(absolutePosSourceLat);
+  CONSOLE.print(" pwmMaxMow=");
+  CONSOLE.print(motor.pwmMaxMow);
+  CONSOLE.print(" finishAndRestart=");
+  CONSOLE.print(finishAndRestart);
+  CONSOLE.print(" motorMowForwardSet=");
+  CONSOLE.println(motor.motorMowForwardSet);
 }
 
 void updateStateOpText(){
@@ -141,12 +147,13 @@ bool loadState(){
   res &= (stateFile.read((uint8_t*)&stateSensor, sizeof(stateSensor)) != 0);
   res &= (stateFile.read((uint8_t*)&sonar.enabled, sizeof(sonar.enabled)) != 0);
   res &= (stateFile.read((uint8_t*)&fixTimeout, sizeof(fixTimeout)) != 0);
-  res &= (stateFile.read((uint8_t*)&setSpeed, sizeof(setSpeed)) != 0);  
+  res &= (stateFile.read((uint8_t*)&setSpeed, sizeof(setSpeed)) != 0);
   res &= (stateFile.read((uint8_t*)&absolutePosSource, sizeof(absolutePosSource)) != 0);
   res &= (stateFile.read((uint8_t*)&absolutePosSourceLon, sizeof(absolutePosSourceLon)) != 0);
   res &= (stateFile.read((uint8_t*)&absolutePosSourceLat, sizeof(absolutePosSourceLat)) != 0);
-  res &= (stateFile.read((uint8_t*)&motor.pwmMaxMow, sizeof(motor.pwmMaxMow)) != 0); 
+  res &= (stateFile.read((uint8_t*)&motor.pwmMaxMow, sizeof(motor.pwmMaxMow)) != 0);
   res &= (stateFile.read((uint8_t*)&finishAndRestart, sizeof(finishAndRestart)) != 0); 
+  res &= (stateFile.read((uint8_t*)&motor.motorMowForwardSet, sizeof(motor.motorMowForwardSet)) != 0); 
   stateFile.close();  
   CONSOLE.println("ok");
   stateCRC = calcStateCRC();
@@ -199,6 +206,7 @@ bool saveState(){
   res &= (stateFile.write((uint8_t*)&absolutePosSourceLat, sizeof(absolutePosSourceLat)) != 0);
   res &= (stateFile.write((uint8_t*)&motor.pwmMaxMow, sizeof(motor.pwmMaxMow)) != 0);  
   res &= (stateFile.write((uint8_t*)&finishAndRestart, sizeof(finishAndRestart)) != 0);  
+  res &= (stateFile.write((uint8_t*)&motor.motorMowForwardSet, sizeof(motor.motorMowForwardSet)) != 0);
   if (res){
     CONSOLE.println("ok");
   } else {

--- a/sunray/motor.h
+++ b/sunray/motor.h
@@ -31,6 +31,7 @@ class Motor {
     bool motorMowOverload; 
     bool tractionMotorsEnabled;       
     bool enableMowMotor;
+    bool motorMowForwardSet; 
     bool odometryError;    
     unsigned long motorOverloadDuration; // accumulated duration (ms)
     int  pwmMax;
@@ -75,7 +76,6 @@ class Motor {
     float motorMowRpmCurrLP;    
     float motorLeftRpmLast;
     float motorRightRpmLast;
-    bool motorMowForwardSet; 
     float motorMowPWMSet;  
     float motorMowPWMCurr; 
     int motorLeftPWMCurr;


### PR DESCRIPTION
Save the mow motor direction to be able to change the mow motor direction if the mower is switched off between two mowing sessions

Issue: If someone don't use a docking station, the mower is switched off after mowing and forgets the last mow motor direction. If someone switches off the mower between two mowing sessions he is not able to benefit of the feature to change to mow motor direction.

This change saves the mow motor direction to be able to change it independend of switching off the mower.

- [X] Test change tho whole last season in sunray 1.0.230
- [X] Rewrite change to new code structure of sunray 1.0.298
- [X] Perform some testruns in sunray 1.0.298
- [X] Merge to master Sunray 1.0.306
- [X] Integrate the pwmMaxMow and finishAndRestart in dump state and calc state CRC additionally
- [X] Perform some testruns in sunray 1.0.306

The only changes by this request are in motor.h (change motorMowForwardSet from private to public) and Storage.cpp (add motorMowForwardSet aus saved value)

