### PR TITLE
Add voltage offset

### DIFF
--- a/sunray/config_example.h
+++ b/sunray/config_example.h
@@ -295,6 +295,8 @@ Also, you may choose the serial port below for serial monitor output (CONSOLE).
 //#define CURRENT_FACTOR 1.98   // PCB1.4 (non-bridged INA169, max. 2.5A)
 //#define CURRENT_FACTOR 2.941  // PCB1.4 (bridged INA169, max. 5A)
 
+#define BATT_VOLTAGE_OFFSET 0.0  // offset to apply to the PCB voltage readings
+
 #define GO_HOME_VOLTAGE   21.5  // start going to dock below this voltage
 // The battery will charge if both battery voltage is below that value and charging current is above that value.
 #define BAT_FULL_VOLTAGE  28.7  // start mowing again at this voltage

--- a/sunray/src/driver/AmRobotDriver.cpp
+++ b/sunray/src/driver/AmRobotDriver.cpp
@@ -581,12 +581,12 @@ void AmBatteryDriver::run(){
     
 float AmBatteryDriver::getBatteryVoltage(){
   float voltage = ((float)ADC2voltage(analogRead(pinBatteryVoltage))) * batteryFactor;
-  return voltage;  
+  return voltage + BATT_VOLTAGE_OFFSET;  
 }
 
 float AmBatteryDriver::getChargeVoltage(){
   float voltage = ((float)ADC2voltage(analogRead(pinChargeVoltage))) * batteryFactor;
-  return voltage;
+  return voltage + BATT_VOLTAGE_OFFSET;
 }
 
 


### PR DESCRIPTION
The PCB seems to read the battery voltage around 0.6 volts lower than it actually is, this PR adds a define to correct that.