### PR TITLE
Odometry: RPM estimation improvements

### DIFF
--- a/sunray/config_example.h
+++ b/sunray/config_example.h
@@ -130,6 +130,8 @@ Also, you may choose the serial port below for serial monitor output (CONSOLE).
 
 // #define TICKS_PER_REVOLUTION  304     // odometry ticks per wheel revolution (RM18)
 
+#define RESPONSIVE_RPM false // use tick time for odometry RPM calculations
+
 
 // ----- gear motors --------------------------------------------------
 // for brushless motors, study the sections (drivers, adapter, protection etc.) in the Wiki (https://wiki.ardumower.de/index.php?title=DIY_Brushless_Driver_Board)

--- a/sunray/motor.cpp
+++ b/sunray/motor.cpp
@@ -296,7 +296,7 @@ void Motor::run() {
   float deltaControlTimeSec =  ((float)(currTime - lastControlTime)) / 1000.0;
   lastControlTime = currTime;
 
-#ifdef RESPONSIVE_RPM
+#if RESPONSIVE_RPM
   unsigned long timeLeft;
   unsigned long timeRight;
   unsigned long timeMow;

--- a/sunray/motor.cpp
+++ b/sunray/motor.cpp
@@ -296,12 +296,33 @@ void Motor::run() {
   float deltaControlTimeSec =  ((float)(currTime - lastControlTime)) / 1000.0;
   lastControlTime = currTime;
 
+#ifdef RESPONSIVE_RPM
+  unsigned long timeLeft;
+  unsigned long timeRight;
+  unsigned long timeMow;
+  motorDriver.getMotorTickTime(timeLeft, timeRight, timeMow);  
+
+  float fTimeLeft = timeLeft / 1000000.0;
+  float fTimeRight = timeRight / 1000000.0;
+  float fTimeMow = timeMow /1000000.0;
+
+  if (motorLeftPWMCurr < 0) fTimeLeft *= -1;
+  if (motorRightPWMCurr < 0) fTimeRight *= -1;
+  if (motorMowPWMCurr < 0) fTimeMow *= -1;
+
+  // calculat speed via tick time
+  motorLeftRpmCurr = (1.0 / (fTimeLeft * (float)ticksPerRevolution)) * 60.0 * (float)(motorLeftPWMCurr != 0);
+  motorRightRpmCurr = (1.0 / (fTimeRight * (float)ticksPerRevolution)) * 60.0 * (float)(motorRightPWMCurr != 0);
+  motorMowRpmCurr = (1.0 / (fTimeMow * 6.0)) * 60.0 * (float)(motorMowPWMCurr != 0);
+#else
   // calculate speed via tick count
   // 2000 ticksPerRevolution: @ 30 rpm  => 0.5 rps => 1000 ticksPerSec
   // 20 ticksPerRevolution: @ 30 rpm => 0.5 rps => 10 ticksPerSec
   motorLeftRpmCurr = 60.0 * ( ((float)ticksLeft) / ((float)ticksPerRevolution) ) / deltaControlTimeSec;
   motorRightRpmCurr = 60.0 * ( ((float)ticksRight) / ((float)ticksPerRevolution) ) / deltaControlTimeSec;
   motorMowRpmCurr = 60.0 * ( ((float)ticksMow) / ((float)6.0) ) / deltaControlTimeSec; // assuming 6 ticks per revolution
+#endif
+	
   float lp = 0.9; // 0.995
   motorLeftRpmCurrLP = lp * motorLeftRpmCurrLP + (1.0-lp) * motorLeftRpmCurr;
   motorRightRpmCurrLP = lp * motorRightRpmCurrLP + (1.0-lp) * motorRightRpmCurr;

--- a/sunray/src/driver/AmRobotDriver.cpp
+++ b/sunray/src/driver/AmRobotDriver.cpp
@@ -110,54 +110,51 @@ float AmRobotDriver::getCpuTemperature(){
 void OdometryMowISR(){			  
   unsigned long now = micros();
   if (digitalRead(pinMotorMowRpm) == LOW) return;
-  if (millis() < motorMowTicksTimeout) return; // eliminate spikes 
+  if (now < motorMowTicksTimeout) return; // eliminate spikes 
   motorMowTickTime = now - motorMowThen;
   motorMowThen = now; 
   #ifdef SUPER_SPIKE_ELIMINATOR
-    unsigned long duration = millis() - motorMowTransitionTime;
-    if (duration > 5) duration = 0;
-    motorMowTransitionTime = millis();
+    unsigned long duration = motorMowTickTime;
+    if (duration > 5000) duration = 0;
     motorMowDurationMax = 0.7 * max(motorMowDurationMax, ((float)duration));
-    motorMowTicksTimeout = millis() + motorMowDurationMax;
+    motorMowTicksTimeout = now + motorMowDurationMax;
   #else
-    motorMowTicksTimeout = millis() + 1;
+    motorMowTicksTimeout = now + 1000;
   #endif
-  odomTicksMow++;      
+  odomTicksMow++;
 }
 
 
 void OdometryLeftISR(){			  
   unsigned long now = micros();
   if (digitalRead(pinOdometryLeft) == LOW) return;
-  if (millis() < motorLeftTicksTimeout) return; // eliminate spikes 
+  if (now < motorLeftTicksTimeout) return; // eliminate spikes 
   motorLeftTickTime = now - motorLeftThen;
   motorLeftThen = now; 
   #ifdef SUPER_SPIKE_ELIMINATOR
-    unsigned long duration = millis() - motorLeftTransitionTime;
-    if (duration > 5) duration = 0;
-    motorLeftTransitionTime = millis();
+    unsigned long duration = motorLeftTickTime;
+    if (duration > 5000) duration = 0;
     motorLeftDurationMax = 0.7 * max(motorLeftDurationMax, ((float)duration));
-    motorLeftTicksTimeout = millis() + motorLeftDurationMax;
+    motorLeftTicksTimeout = now + motorLeftDurationMax;
   #else
-    motorLeftTicksTimeout = millis() + 1;
+    motorLeftTicksTimeout = now + 1000;
   #endif
-  odomTicksLeft++;     
+  odomTicksLeft++;    
 }
 
 void OdometryRightISR(){			
   unsigned long now = micros();
   if (digitalRead(pinOdometryRight) == LOW) return;  
-  if (millis() < motorRightTicksTimeout) return; // eliminate spikes
+  if (now < motorRightTicksTimeout) return; // eliminate spikes
   motorRightTickTime = now - motorRightThen;
   motorRightThen = now;
   #ifdef SUPER_SPIKE_ELIMINATOR
-    unsigned long duration = millis() - motorRightTransitionTime;
-    if (duration > 5) duration = 0;  
-    motorRightTransitionTime = millis();
+    unsigned long duration = motorRightTickTime;
+    if (duration > 5000) duration = 0;  
     motorRightDurationMax = 0.7 * max(motorRightDurationMax, ((float)duration));  
-    motorRightTicksTimeout = millis() + motorRightDurationMax;
+    motorRightTicksTimeout = now + motorRightDurationMax;
   #else
-    motorRightTicksTimeout = millis() + 1;
+    motorRightTicksTimeout = now + 1000;
   #endif
   odomTicksRight++;        
   

--- a/sunray/src/driver/AmRobotDriver.h
+++ b/sunray/src/driver/AmRobotDriver.h
@@ -72,6 +72,7 @@ class AmMotorDriver: public MotorDriver {
     void resetMotorFaults()  override;
     void getMotorCurrent(float &leftCurrent, float &rightCurrent, float &mowCurrent) override;
     void getMotorEncoderTicks(int &leftTicks, int &rightTicks, int &mowTicks) override;
+    void getMotorTickTime(unsigned long &leftTime, unsigned long &rightTime, unsigned long &mowTime);
   protected:
     int lastLeftPwm;
     int lastRightPwm;


### PR DESCRIPTION
The problem:
RPM is calculated sampling ticks in a given amount of time, 50 ms in this case.
This gives aliased data and, in some cases, no data at all, for my 150 ticks per revolution motor at 0.1m/s the ticks per sampling time oscilate between 1 and 0, that can give the PID controller an oscillation of 100% speed to work with, even at higher RPMs the difference can still be 25% between measured and actual speed.
This makes the wheels very jittery at low speeds.

Soution:
Instead of using ticks per time, use time per tick and  take its reciprocal, we have an accurate reprentation of time per tick recording the time that happens between each interrupt.
For low tick count motors like mine  this makes a world of a difference and the wheels turn A LOT smoother.

I cant test Alfred but the changes to the firmware should basically be the same, I could add that If you want to merge this.