### PR TITLE
line tracker: add steering restriction as optional

### DIFF
--- a/sunray/LineTracker.cpp
+++ b/sunray/LineTracker.cpp
@@ -268,7 +268,9 @@ void trackLine(bool runControl){
     //CONSOLE.println(angular/PI*180.0);            
     if (maps.trackReverse) linear *= -1;   // reverse line tracking needs negative speed
     // restrict steering angle for stanley  (not required anymore after last state estimation bugfix)
-    //if (!SMOOTH_CURVES) angular = max(-PI/16, min(PI/16, angular)); 
+    if (STANLEY_STEERING_RESTRICTION) {
+      if (!SMOOTH_CURVES) angular = max(-PI/16, min(PI/16, angular));
+    }
   }
   // check some pre-conditions that can make linear+angular speed zero
   if (fixTimeout != 0){

--- a/sunray/config_example.h
+++ b/sunray/config_example.h
@@ -394,6 +394,7 @@ Also, you may choose the serial port below for serial monitor output (CONSOLE).
 #define STANLEY_CONTROL_P_SLOW    3.0   // 3.0 for path tracking control (angular gain) when docking tracking
 #define STANLEY_CONTROL_K_SLOW    0.1   // 0.1 for path tracking control (lateral gain) when docking tracking
 
+#define STANLEY_STEERING_RESTRICTION false   // restrict steering angle for stanley (set to true to activate)
 
 // ----- other options --------------------------------------------
 


### PR DESCRIPTION
To remove the sudden occurring turns at waypoints since removed steering restrictions for stanlay an option is intruduced to be able to decide if this restriction should be used or not.

Relates to Issue #144 "Mower correts path too agressively at low speeds."