### PR TITLE
Small Sonar Improvements

### DIFF
--- a/sunray/config_example.h
+++ b/sunray/config_example.h
@@ -253,6 +253,7 @@ Also, you may choose the serial port below for serial monitor output (CONSOLE).
 #define SONAR_INSTALLED 1              // uncomment if ultrasonic sensors are installed
 //#define SONAR_ENABLE true              // should ultrasonic sensor be used?
 #define SONAR_ENABLE false
+#define SONAR_OBSTACLE_SLOW_CM 30        // slow down mower below this distance from trigger (cm)
 #define SONAR_TRIGGER_OBSTACLES true     // should sonar be used to trigger obstacles? if not, mower will only slow down
 #define SONAR_LEFT_OBSTACLE_CM   10      // stop mowing operation below this distance (cm) 
 #define SONAR_CENTER_OBSTACLE_CM 10      // stop mowing operation below this distance (cm) 

--- a/sunray/sonar.cpp
+++ b/sunray/sonar.cpp
@@ -122,9 +122,22 @@ void Sonar::run() {
 
   if (millis() > timeoutTime) {
     if (!added) {
-      if (sonarIdx == 0) sonarLeftMeasurements.add(MAX_DURATION);
-      else if (sonarIdx == 1) sonarCenterMeasurements.add(MAX_DURATION);
-      else sonarRightMeasurements.add(MAX_DURATION);
+      unsigned int td;
+      if (sonarIdx == 0) {
+        sonarLeftMeasurements.add(MAX_DURATION);
+        sonarLeftMeasurements.getMedian(td);
+        distanceLeft = convertCm(td);
+      }
+      else if (sonarIdx == 1) {
+        sonarCenterMeasurements.add(MAX_DURATION);
+        sonarCenterMeasurements.getMedian(td);
+        distanceCenter = convertCm(td);
+      }
+      else if (sonarIdx == 2) {
+        sonarRightMeasurements.add(MAX_DURATION);
+        sonarRightMeasurements.getMedian(td);
+        distanceRight = convertCm(td);
+      }
     }
     //if (millis() > nextSonarTime){
     sonarIdx = (sonarIdx + 1) % 3;


### PR DESCRIPTION
Small PR.

- Makes the sonar slow distance configurable.
- Reduces lag by using 3 samples for the running median, 9 was excessively overkill.
- Reduces lag by setting the distances to its public variables everytime a new measurement comes in.