### PR TITLE
Battery voltage measurement through INA226

### DIFF
--- a/sunray/LineTracker.cpp
+++ b/sunray/LineTracker.cpp
@@ -223,10 +223,11 @@ void trackLine(bool runControl){
 
     if (maps.trackSlow && trackslow_allowed) {
       // planner forces slow tracking (e.g. docking etc)
-      linear = 0.1;           
-    } else if (     ((setSpeed > 0.2) && (maps.distanceToTargetPoint(stateX, stateY) < 0.5) && (!straight))   // approaching
-          || ((linearMotionStartTime != 0) && (millis() < linearMotionStartTime + 3000))                      // leaving  
-       ) 
+      linear = DOCK_SPEED;
+    }
+    else if (((setSpeed > 0.2) && (maps.distanceToTargetPoint(stateX, stateY) < 0.5) && (!straight)) // approaching
+             || ((linearMotionStartTime != 0) && (millis() < linearMotionStartTime + 3000))          // leaving
+    )
     {
       linear = 0.1; // reduce speed when approaching/leaving waypoints          
     } 

--- a/sunray/config_example.h
+++ b/sunray/config_example.h
@@ -300,6 +300,9 @@ Also, you may choose the serial port below for serial monitor output (CONSOLE).
 #define BAT_SWITCH_OFF_IDLE  false         // switch off if idle (JP8 must be set to autom.)
 #define BAT_SWITCH_OFF_UNDERVOLTAGE  true  // switch off if undervoltage (JP8 must be set to autom.)
 
+// in case an INA226 sensor is installed to measure the battery voltage more accurately
+#define INA226_BATT_VOLT // comment out if no INA226 is used measuring battery voltage
+#define INA226_ADDRESS 0x40
 
 // ------ GPS ------------------------------------------
 // ------- RTK GPS module -----------------------------------
@@ -382,6 +385,8 @@ Also, you may choose the serial port below for serial monitor output (CONSOLE).
 #define DOCK_UNDOCK_TRACKSLOW_DISTANCE 5 // set distance (m) from dock for trackslow (speed limit)
 
 #define UNDOCK_IGNORE_GPS_DISTANCE 2 // set distance (m) from dock to ignore gps while undocking
+
+#define DOCK_SPEED 0.07 // speed to dock (m/s)
 
 // ---- path tracking -----------------------------------
 

--- a/sunray/robot.cpp
+++ b/sunray/robot.cpp
@@ -671,7 +671,46 @@ void start(){
   #endif
 }
 
+#ifdef INA226_BATT_VOLT
+  // ina 226, tried to reuse the functions from i2c.h/cpp
+  I2CScanner();
 
+  byte error = 1;
+
+  Wire.beginTransmission(INA226_ADDRESS);
+  error = Wire.endTransmission();
+  if (error == 0)
+  {
+    // Configure the INA226
+    uint16_t config = 0;
+
+    // Set bus voltage range to 32V (V_BUS_CT = 0b10)
+    config |= (0x2 << 9);
+
+    // Set bus voltage conversion time to 140us (VBUS_CT = 0b01)
+    config |= (0x1 << 5);
+
+    // Set averaging mode to 64 samples (AVG = 0b10)
+    config |= (0x2 << 3);
+
+    // Set continuous shunt and bus voltage conversions (CONT_SHUNT = CONT_BUS = 1)
+    config |= (0x1 << 2); // CONT_SHUNT
+    config |= (0x1 << 3); // CONT_BUS
+
+    // Enable the INA226 (ENABLE = 1)
+    config |= 0x1;
+
+    // Write configuration to the configuration register (0x00)
+    I2CwriteTo(INA226_ADDRESS, 0x00, config & 0xFF); // Writing low byte
+    I2CwriteTo(INA226_ADDRESS, 0x01, config >> 8);   // Writing high byte
+  }
+  else
+  {
+    CONSOLE.println("INA226 not found");
+  }
+
+#endif
+}
 
 // should robot move?
 bool robotShouldMove(){

--- a/sunray/src/driver/AmRobotDriver.h
+++ b/sunray/src/driver/AmRobotDriver.h
@@ -11,7 +11,7 @@
 #include <Arduino.h>
 #include "RobotDriver.h"
 #include "../../SparkFunHTU21D.h"
-
+#include "../../i2c.h"
 
 #ifndef __linux__
 


### PR DESCRIPTION
1) 
Since there is some offset* issue with battery voltage, added functionality to read battery voltage through an INA226 (most batteries have a spare connection anyway to easily connect a sensor to).
I've tried to just use the already existing i2c functions.

*on my robot the 3.3 voltage is just floating weirdly throwing off battery voltage measurements.
In other forum posts some people play with varying offset values in the code.

2) added an extra parameter for the speed when approaching the docking station