### PR TITLE
Ability to suppress docking after mowing.

### DIFF
--- a/sunray/Storage.cpp
+++ b/sunray/Storage.cpp
@@ -21,7 +21,7 @@ double calcStateCRC(){
  return (stateOp *10 + maps.mowPointsIdx + maps.dockPointsIdx + maps.freePointsIdx + ((byte)maps.wayMode) 
    + sonar.enabled + fixTimeout + setSpeed + ((byte)sonar.enabled)
    + ((byte)absolutePosSource) + absolutePosSourceLon + absolutePosSourceLat + motor.pwmMaxMow 
-   + ((byte)finishAndRestart) + ((byte)motor.motorMowForwardSet) + ((byte)battery.docked)
+   + ((byte)finishAndRestart) + ((byte)motor.motorMowForwardSet) + ((byte)battery.docked) + ((byte)dockAfterFinish)
    + timetable.crc() );
 }
 
@@ -63,7 +63,9 @@ void dumpState(){
   CONSOLE.print(" finishAndRestart=");
   CONSOLE.print(finishAndRestart);
   CONSOLE.print(" motorMowForwardSet=");
-  CONSOLE.println(motor.motorMowForwardSet);  
+  CONSOLE.print(motor.motorMowForwardSet);  
+  CONSOLE.print(" dockAfterFinish=");
+  CONSOLE.println(dockAfterFinish);
 }
 
 void updateStateOpText(){
@@ -158,6 +160,7 @@ bool loadState(){
   res &= (stateFile.read((uint8_t*)&motor.motorMowForwardSet, sizeof(motor.motorMowForwardSet)) != 0); 
   res &= (stateFile.read((uint8_t*)&timetable.timetable, sizeof(timetable.timetable)) != 0);
   res &= (stateFile.read((uint8_t*)&battery.docked, sizeof(battery.docked)) != 0);  
+  res &= (stateFile.read((uint8_t*)&dockAfterFinish, sizeof(dockAfterFinish)) != 0);
   stateFile.close();  
   CONSOLE.println("ok");
   stateCRC = calcStateCRC();
@@ -213,7 +216,8 @@ bool saveState(){
   res &= (stateFile.write((uint8_t*)&finishAndRestart, sizeof(finishAndRestart)) != 0);  
   res &= (stateFile.write((uint8_t*)&motor.motorMowForwardSet, sizeof(motor.motorMowForwardSet)) != 0);
   res &= (stateFile.write((uint8_t*)&timetable.timetable, sizeof(timetable.timetable)) != 0);  
-  res &= (stateFile.write((uint8_t*)&battery.docked, sizeof(battery.docked)) != 0);  
+  res &= (stateFile.write((uint8_t*)&battery.docked, sizeof(battery.docked)) != 0);
+  res &= (stateFile.write((uint8_t*)&dockAfterFinish, sizeof(dockAfterFinish)) != 0);  
   if (res){
     CONSOLE.println("ok");
   } else {

--- a/sunray/comm.cpp
+++ b/sunray/comm.cpp
@@ -165,6 +165,8 @@ void cmdControl(){
           if (intValue >= 0) motor.setMowMaxPwm(intValue);
       } else if (counter == 10){
           if (intValue >= 0) motor.setMowHeightMillimeter(intValue);
+      } else if (counter == 11){
+          if (intValue >= 0) dockAfterFinish = (intValue == 1);
       }
       counter++;
       lastCommaIdx = idx;

--- a/sunray/robot.cpp
+++ b/sunray/robot.cpp
@@ -155,6 +155,7 @@ float lastGPSMotionY = 0;
 unsigned long nextGPSMotionCheckTime = 0;
 
 bool finishAndRestart = false;
+bool dockAfterFinish = true;
 
 unsigned long nextBadChargingContactCheck = 0;
 unsigned long nextToFTime = 0;

--- a/sunray/robot.h
+++ b/sunray/robot.h
@@ -87,6 +87,7 @@ extern float stateTemp;  // current temperature
 extern float setSpeed; // linear speed (m/s)
 extern int fixTimeout;
 extern bool finishAndRestart; // auto-restart when mowing finished?
+extern bool dockAfterFinish; // dock after mowing finished?
 extern bool absolutePosSource;
 extern double absolutePosSourceLon;
 extern double absolutePosSourceLat;

--- a/sunray/src/op/ChargeOp.cpp
+++ b/sunray/src/op/ChargeOp.cpp
@@ -104,6 +104,8 @@ void ChargeOp::run(){
                 CONSOLE.print(timetable.mowingAllowed());
                 CONSOLE.print(", finishAndRestart=");                
                 CONSOLE.print(finishAndRestart);                
+                CONSOLE.print(", dockAfterFinish=");
+                CONSOLE.print(dockAfterFinish);
                 CONSOLE.println(")");
             }
             if (timetable.shouldAutostartNow()){

--- a/sunray/src/op/MowOp.cpp
+++ b/sunray/src/op/MowOp.cpp
@@ -286,7 +286,7 @@ void MowOp::onNoFurtherWaypoints(){
     Logger.event(EVT_MOWING_COMPLETED);
     timetable.setMowingCompletedInCurrentTimeFrame(true);
     if (!finishAndRestart){             
-        if (DOCKING_STATION){
+        if (DOCKING_STATION && dockAfterFinish){
             dockOp.setInitiatedByOperator(false);
             changeOp(dockOp);               
         } else {


### PR DESCRIPTION
- The command is issued via the AT+C command
- The command is useful when you issue the "go to" command via CaSSAndRA. So far, CaSSAndRA is working with a workaround in which the map is transferred without a dock path. This only works when the mower is not docked. With this change, the "go to" command works in every situation